### PR TITLE
Create 'data' folder for portable mode

### DIFF
--- a/vscode.portable/tools/ChocolateyInstall.ps1
+++ b/vscode.portable/tools/ChocolateyInstall.ps1
@@ -9,9 +9,11 @@ $Url64 = 'https://vscode-update.azurewebsites.net/' + $Version + '/win32-x64-arc
 $ChecksumType64 = 'sha256'
 $Checksum64 = '7ea542a5ba4f307123b6a3a21fc4eab103b28291a3d91b817f08d5102d270b3e'
 $InstallationPath = Join-Path $(Get-ToolsLocation) $PackageName
+$DataPath = Join-Path $InstallationPath 'data'
 
 Get-ChildItem -Path $InstallationPath -Exclude data -ErrorAction Ignore | Remove-Item -Recurse -Force -ErrorAction Ignore
 New-Item -ItemType Directory -Path $InstallationPath -Force -ErrorAction Ignore
+New-Item -ItemType Directory -Path $DataPath -Force -ErrorAction Ignore
 
 $PackageArgs = @{
     PackageName    = $PackageName


### PR DESCRIPTION
We need to create this 'data' folder to actually enter portable mode, otherwise the user data will be stored on %APPDATA% and %USERPROFILE% folders.

I have always had vscode installed in portable mode and only used this package for updates so I never noticed this important step was missing! (until I had to install it in a new machine)

This change might make it so people, who had installed it through this package, after making this update won't see their extensions installed and settings reset to default.

To fix this, they will need to do the following:

1. Copy the contents from the folder "%APPDATA%\Code\" to the new folder "data\user-data\"
2. Copy the contents from the folder "%USERPROFILE%\.vscode\" to the new folder "data"

These 2 steps should leave everything working the same way as before, except now in true portable mode.

Maybe this update should give a warning to the users?

